### PR TITLE
Reimplement `MapWithWithMove` in terms of `MapWithPatchingMove`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -43,3 +43,5 @@ jobs:
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
       run: cabal test all
+    - name: Build Docs
+      run: cabal haddock

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 * Rewrite `PatchMapWithMove` in terms of `PatchMapWithPatchingMove`.
-  Care is taken to make this as little of a breaking change as possible.
-  In particular, `PatchMapWithMove` is a newtype of `PatchMapWithPatchingMove` as is the `NodeInfo` of `PatchMapWithPatchingMove`'s `NodeInfo`.
+  Care is taken to make this not a breaking change.
+  In particular, `PatchMapWithMove` is a newtype of `PatchMapWithPatchingMove`, as is the `NodeInfo` and `From` of `PatchMapWithPatchingMove`'s versions of those.
+  There are complete constructor and field patterns too, and everything is
+  exported under the newtype as real constructors and fields would be.
 
 ## 0.0.4.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for patch
 
+## 0.1.0.0
+
+* Rewrite `PatchMapWithMove` in terms of `PatchMapWithPatchingMove`.
+  Care is taken to make this as little of a breaking change as possible.
+  In particular, `PatchMapWithMove` is a newtype of `PatchMapWithPatchingMove` as is the `NodeInfo` of `PatchMapWithPatchingMove`'s `NodeInfo`.
+
 ## 0.0.3.0
 
 * Create `PatchMapWithPatchingMove` variant which supports moves with a patch.

--- a/src/Data/Patch/Class.hs
+++ b/src/Data/Patch/Class.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 -- | The interface for types which represent changes made to other types
 module Data.Patch.Class where
 
 import Data.Functor.Identity
+import Data.Kind (Type)
 import Data.Maybe
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup(..))
@@ -15,7 +17,7 @@ import Data.Proxy
 -- If an instance of 'Patch' is also an instance of 'Semigroup', it should obey
 -- the law that @applyAlways (f <> g) == applyAlways f . applyAlways g@.
 class Patch p where
-  type PatchTarget p :: *
+  type PatchTarget p :: Type
   -- | Apply the patch @p a@ to the value @a@.  If no change is needed, return
   -- 'Nothing'.
   apply :: p -> PatchTarget p -> Maybe (PatchTarget p)
@@ -30,7 +32,7 @@ instance Patch (Identity a) where
   apply (Identity a) _ = Just a
 
 -- | 'Proxy' can be used as a 'Patch' that does nothing.
-instance Patch (Proxy (a :: *)) where
+instance forall (a :: Type). Patch (Proxy a) where
   type PatchTarget (Proxy a) = a
   apply ~Proxy _ = Nothing
 

--- a/src/Data/Patch/DMapWithMove.hs
+++ b/src/Data/Patch/DMapWithMove.hs
@@ -220,8 +220,8 @@ moveDMapKey src dst = case src `geq` dst of
 -- @
 --     let aMay = DMap.lookup a dmap
 --         bMay = DMap.lookup b dmap
---     in maybe id (DMap.insert a) (bMay `mplus` aMay)
---      . maybe id (DMap.insert b) (aMay `mplus` bMay)
+--     in maybe id (DMap.insert a) (bMay <> aMay)
+--      . maybe id (DMap.insert b) (aMay <> bMay)
 --      . DMap.delete a . DMap.delete b $ dmap
 -- @
 swapDMapKey :: GCompare k => k a -> k a -> PatchDMapWithMove k v

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -65,11 +65,8 @@ module Data.Patch.MapWithMove
 import Data.Coerce
 import Data.Kind (Type)
 import Data.Patch.Class
-import Data.Patch.MapWithPatchingMove
-  ( PatchMapWithPatchingMove (..)
-  )
-import qualified Data.Patch.MapWithPatchingMove as PM
-import Data.Patch.MapWithPatchingMove (To) -- already a transparent synonym
+import Data.Patch.MapWithPatchingMove (PatchMapWithPatchingMove(..), To)
+import qualified Data.Patch.MapWithPatchingMove as PM -- already a transparent synonym
 
 import Control.Lens hiding (from, to)
 import Data.List
@@ -226,11 +223,11 @@ deriving instance (Ord k, Ord p) => Ord (NodeInfo k p)
 pattern NodeInfo :: To k -> From k v -> NodeInfo k v
 _nodeInfo_to :: NodeInfo k v -> To k
 _nodeInfo_from :: NodeInfo k v -> From k v
-pattern NodeInfo { _nodeInfo_to, _nodeInfo_from } =
-  NodeInfo' (PM.NodeInfo
+pattern NodeInfo { _nodeInfo_to, _nodeInfo_from } = NodeInfo'
+  PM.NodeInfo
     { PM._nodeInfo_to = _nodeInfo_to
     , PM._nodeInfo_from = Coerce _nodeInfo_from
-    })
+    }
 
 _NodeInfo
   :: Iso
@@ -295,7 +292,7 @@ pattern From_Insert v = From' (PM.From_Insert v)
 
 -- | Delete the existing value, if any, from here
 pattern From_Delete :: From k v
-pattern From_Delete = From' (PM.From_Delete)
+pattern From_Delete = From' PM.From_Delete
 
 -- | Move the value here from the given key
 pattern From_Move :: k -> From k v

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -156,8 +156,8 @@ moveMapKey src dst = PatchMapWithMove' $ PM.moveMapKey src dst
 -- @
 --     let aMay = Map.lookup a map
 --         bMay = Map.lookup b map
---     in maybe id (Map.insert a) (bMay `mplus` aMay)
---      . maybe id (Map.insert b) (aMay `mplus` bMay)
+--     in maybe id (Map.insert a) (bMay <> aMay)
+--      . maybe id (Map.insert b) (aMay <> bMay)
 --      . Map.delete a . Map.delete b $ map
 -- @
 swapMapKey :: Ord k => k -> k -> PatchMapWithMove k v

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -84,9 +84,13 @@ newtype PatchMapWithMove k (v :: Type) = PatchMapWithMove'
     unPatchMapWithMove' :: PatchMapWithPatchingMove k (Proxy v)
   }
   deriving ( Show, Read, Eq, Ord
-           , -- | Compose patches having the same effect as applying the
+-- Haddock cannot handle documentation here before GHC 8.6
+           ,
+#if __GLASGOW_HASKELL__ >= 806
+             -- | Compose patches having the same effect as applying the
              -- patches in turn: @'applyAlways' (p <> q) == 'applyAlways' p .
              -- 'applyAlways' q@
+#endif
              Semigroup
            , Monoid
            )

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -244,11 +244,7 @@ instance Foldable (NodeInfo k) where
   foldMap = foldMapDefault
 
 instance Traversable (NodeInfo k) where
-  traverse = _NodeInfo . traverseNodeInfo
-    where
-      traverseNodeInfo
-        :: Traversal (PM.NodeInfo k (Proxy a)) (PM.NodeInfo k (Proxy b)) a b
-      traverseNodeInfo = PM.bitraverseNodeInfo pure (\ ~Proxy -> pure Proxy)
+  traverse = bitraverseNodeInfo pure
 
 bitraverseNodeInfo
   :: Applicative f

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -100,7 +100,7 @@ type To k = PM.To k
 
 traverseNodeInfo
   :: Traversal (NodeInfo k a) (NodeInfo k b) a b
-traverseNodeInfo = PM.bitraverseNodeInfo pure (\(~Proxy) -> pure Proxy)
+traverseNodeInfo = PM.bitraverseNodeInfo pure (\ ~Proxy -> pure Proxy)
 
 -- | Create a 'PatchMapWithMove', validating it
 patchMapWithMove :: Ord k => Map k (NodeInfo k v) -> Maybe (PatchMapWithMove k v)
@@ -147,7 +147,7 @@ unsafePatchMapWithMove = PatchMapWithMove' . PM.unsafePatchMapWithPatchingMove
 -- | Apply the insertions, deletions, and moves to a given 'Map'
 instance Ord k => Patch (PatchMapWithMove k v) where
   type PatchTarget (PatchMapWithMove k v) = Map k v
-  apply (PatchMapWithMove' p) old = apply p old
+  apply (PatchMapWithMove' p) = apply p
 
 -- | Returns all the new elements that will be added to the 'Map'.
 patchMapWithMoveNewElements :: PatchMapWithMove k v -> [v]

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -68,7 +68,7 @@ import Data.Patch.Class
 import Data.Patch.MapWithPatchingMove (PatchMapWithPatchingMove(..), To)
 import qualified Data.Patch.MapWithPatchingMove as PM -- already a transparent synonym
 
-import Control.Lens hiding (from, to)
+import Control.Lens
 import Data.List
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -137,7 +137,7 @@ instance TraversableWithIndex k (PatchMapWithMove k) where
 
 -- | Create a 'PatchMapWithMove', validating it
 patchMapWithMove :: Ord k => Map k (NodeInfo k v) -> Maybe (PatchMapWithMove k v)
-patchMapWithMove = fmap coerce . PM.patchMapWithPatchingMove . coerce
+patchMapWithMove = fmap PatchMapWithMove' . PM.patchMapWithPatchingMove . coerce
 
 -- | Create a 'PatchMapWithMove' that inserts everything in the given 'Map'
 patchMapWithMoveInsertAll :: Map k v -> PatchMapWithMove k v
@@ -175,7 +175,7 @@ deleteMapKey = PatchMapWithMove' . PM.deleteMapKey
 --
 -- __Warning:__ when using this function, you must ensure that the invariants of 'PatchMapWithMove' are preserved; they will not be checked.
 unsafePatchMapWithMove :: Map k (NodeInfo k v) -> PatchMapWithMove k v
-unsafePatchMapWithMove = PatchMapWithMove' . PM.unsafePatchMapWithPatchingMove . coerce
+unsafePatchMapWithMove = coerce PM.unsafePatchMapWithPatchingMove
 
 -- | Apply the insertions, deletions, and moves to a given 'Map'
 instance Ord k => Patch (PatchMapWithMove k v) where
@@ -199,7 +199,7 @@ patchThatSortsMapWith cmp = PatchMapWithMove' . PM.patchThatSortsMapWith cmp
 -- | Create a 'PatchMapWithMove' that, if applied to the first 'Map' provided,
 -- will produce a 'Map' with the same values as the second 'Map' but with the
 -- values sorted with the given ordering function.
-patchThatChangesAndSortsMapWith :: forall k v. (Ord k, Ord v) => (v -> v -> Ordering) -> Map k v -> Map k v -> PatchMapWithMove k v
+patchThatChangesAndSortsMapWith :: (Ord k, Ord v) => (v -> v -> Ordering) -> Map k v -> Map k v -> PatchMapWithMove k v
 patchThatChangesAndSortsMapWith cmp oldByIndex newByIndexUnsorted = patchThatChangesMap oldByIndex newByIndex
   where newList = Map.toList newByIndexUnsorted
         newByIndex = Map.fromList $ zip (fst <$> newList) $ sortBy cmp $ snd <$> newList
@@ -255,13 +255,13 @@ bitraverseNodeInfo
   => (k0 -> f k1)
   -> (v0 -> f v1)
   -> NodeInfo k0 v0 -> f (NodeInfo k1 v1)
-bitraverseNodeInfo fk fv = fmap coerce
+bitraverseNodeInfo fk fv = fmap NodeInfo'
   . PM.bitraverseNodeInfo fk (\ ~Proxy -> pure Proxy) fv
   . coerce
 
 -- | Change the 'From' value of a 'NodeInfo'
 nodeInfoMapFrom :: (From k v -> From k v) -> NodeInfo k v -> NodeInfo k v
-nodeInfoMapFrom f = coerce . PM.nodeInfoMapFrom (unFrom' . f . From') . coerce
+nodeInfoMapFrom f = coerce $ PM.nodeInfoMapFrom (unFrom' . f . From')
 
 -- | Change the 'From' value of a 'NodeInfo', using a 'Functor' (or
 -- 'Applicative', 'Monad', etc.) action to get the new value
@@ -269,7 +269,7 @@ nodeInfoMapMFrom
   :: Functor f
   => (From k v -> f (From k v))
   -> NodeInfo k v -> f (NodeInfo k v)
-nodeInfoMapMFrom f = fmap coerce
+nodeInfoMapMFrom f = fmap NodeInfo'
   . PM.nodeInfoMapMFrom (fmap unFrom' . f . From')
   . coerce
 
@@ -303,7 +303,7 @@ bitraverseFrom
   => (k0 -> f k1)
   -> (v0 -> f v1)
   -> From k0 v0 -> f (From k1 v1)
-bitraverseFrom fk fv = fmap coerce
+bitraverseFrom fk fv = fmap From'
   . PM.bitraverseFrom fk (\ ~Proxy -> pure Proxy) fv
   . coerce
 

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -2,9 +2,11 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -12,88 +14,105 @@
 
 -- | 'Patch'es on 'Map' that can insert, delete, and move values from one key to
 -- another
-module Data.Patch.MapWithMove where
+module Data.Patch.MapWithMove
+  ( module Data.Patch.MapWithMove
+  , PatchMapWithMove (PatchMapWithMove)
+  , NodeInfo
+  , pattern PM.NodeInfo
+  , PM._nodeInfo_to
+  , PM._nodeInfo_from
+  ) where
 
 import Data.Patch.Class
+import Data.Patch.MapWithPatchingMove
+  ( PatchMapWithPatchingMove (..)
+  )
+import qualified Data.Patch.MapWithPatchingMove as PM
 
-import Control.Arrow
 import Control.Lens hiding (from, to)
-import Control.Monad.Trans.State
-import Data.Foldable
-import Data.Function
 import Data.List
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe
+import Data.Proxy
 #if !MIN_VERSION_base(4,10,0)
-import Data.Semigroup (Semigroup (..), (<>))
+import Data.Semigroup (Semigroup (..))
 #endif
-import qualified Data.Set as Set
-import Data.These (These(..))
-import Data.Tuple
+import Data.Traversable (foldMapDefault)
 
 -- | Patch a Map with additions, deletions, and moves.  Invariant: If key @k1@
 -- is coming from @From_Move k2@, then key @k2@ should be going to @Just k1@,
 -- and vice versa.  There should never be any unpaired From/To keys.
-newtype PatchMapWithMove k v = PatchMapWithMove
-  { -- | Extract the internal representation of the 'PatchMapWithMove'
-    unPatchMapWithMove :: Map k (NodeInfo k v)
+newtype PatchMapWithMove k v = PatchMapWithMove'
+  { -- | Extract the underlying 'PatchMapWithPatchingMove k (Proxy v)'
+    unPatchMapWithMove' :: PatchMapWithPatchingMove k (Proxy v)
   }
   deriving ( Show, Read, Eq, Ord
-           , Functor, Foldable, Traversable
+           , Semigroup, Monoid
            )
 
--- | Holds the information about each key: where its new value should come from,
--- and where its old value should go to
-data NodeInfo k v = NodeInfo
-  { _nodeInfo_from :: !(From k v)
-    -- ^ Where do we get the new value for this key?
-  , _nodeInfo_to :: !(To k)
-    -- ^ If the old value is being kept (i.e. moved rather than deleted or
-    -- replaced), where is it going?
-  }
-  deriving (Show, Read, Eq, Ord, Functor, Foldable, Traversable)
+{-# COMPLETE PatchMapWithMove #-}
+pattern PatchMapWithMove :: Map k (NodeInfo k v) -> PatchMapWithMove k v
+pattern PatchMapWithMove m = PatchMapWithMove' (PatchMapWithPatchingMove m)
 
--- | Describe how a key's new value should be produced
-data From k v
-   = From_Insert v -- ^ Insert the given value here
-   | From_Delete -- ^ Delete the existing value, if any, from here
-   | From_Move !k -- ^ Move the value here from the given key
-   deriving (Show, Read, Eq, Ord, Functor, Foldable, Traversable)
+-- | Extract the internal representation of the 'PatchMapWithMove'
+unPatchMapWithMove :: PatchMapWithMove k v -> Map k (PM.NodeInfo k (Proxy v))
+unPatchMapWithMove = unPatchMapWithPatchingMove . unPatchMapWithMove'
 
--- | Describe where a key's old value will go.  If this is 'Just', that means
--- the key's old value will be moved to the given other key; if it is 'Nothing',
--- that means it will be deleted.
-type To = Maybe
+instance Functor (PatchMapWithMove k) where
+  fmap f = runIdentity . traverse (Identity . f)
 
-makeWrapped ''PatchMapWithMove
+instance Foldable (PatchMapWithMove k) where
+  foldMap = foldMapDefault
+
+instance Traversable (PatchMapWithMove k) where
+  traverse =
+    _Wrapping PatchMapWithMove' .
+    _Wrapping PatchMapWithPatchingMove .
+    traverse .
+    traverseNodeInfo
 
 instance FunctorWithIndex k (PatchMapWithMove k)
 instance FoldableWithIndex k (PatchMapWithMove k)
 instance TraversableWithIndex k (PatchMapWithMove k) where
   itraverse = itraversed . Indexed
-  itraversed = _Wrapped .> itraversed <. traversed
+  itraversed =
+    _Wrapping PatchMapWithMove' .>
+    _Wrapping PatchMapWithPatchingMove .>
+    itraversed <.
+    traverseNodeInfo
+
+type NodeInfo k v = PM.NodeInfo k (Proxy v)
+
+type From k v = PM.From k (Proxy v)
+
+{-# COMPLETE From_Insert, From_Delete, From_Move #-}
+
+pattern From_Insert :: v -> From k v
+pattern From_Insert v = PM.From_Insert v
+
+pattern From_Delete :: From k v
+pattern From_Delete = PM.From_Delete
+
+pattern From_Move :: k -> From k v
+pattern From_Move k = PM.From_Move k Proxy
+
+type To k = PM.To k
+
+traverseNodeInfo
+  :: Traversal (NodeInfo k a) (NodeInfo k b) a b
+traverseNodeInfo = PM.bitraverseNodeInfo pure (\(~Proxy) -> pure Proxy)
 
 -- | Create a 'PatchMapWithMove', validating it
 patchMapWithMove :: Ord k => Map k (NodeInfo k v) -> Maybe (PatchMapWithMove k v)
-patchMapWithMove m = if valid then Just $ PatchMapWithMove m else Nothing
-  where valid = forwardLinks == backwardLinks
-        forwardLinks = Map.mapMaybe _nodeInfo_to m
-        backwardLinks = Map.fromList $ catMaybes $ flip fmap (Map.toList m) $ \(to, v) ->
-          case _nodeInfo_from v of
-            From_Move from -> Just (from, to)
-            _ -> Nothing
+patchMapWithMove = fmap PatchMapWithMove' . PM.patchMapWithPatchingMove
 
 -- | Create a 'PatchMapWithMove' that inserts everything in the given 'Map'
 patchMapWithMoveInsertAll :: Map k v -> PatchMapWithMove k v
-patchMapWithMoveInsertAll m = PatchMapWithMove $ flip fmap m $ \v -> NodeInfo
-  { _nodeInfo_from = From_Insert v
-  , _nodeInfo_to = Nothing
-  }
+patchMapWithMoveInsertAll = PatchMapWithMove' . PM.patchMapWithPatchingMoveInsertAll
 
 -- | Make a @'PatchMapWithMove' k v@ which has the effect of inserting or updating a value @v@ to the given key @k@, like 'Map.insert'.
 insertMapKey :: k -> v -> PatchMapWithMove k v
-insertMapKey k v = PatchMapWithMove . Map.singleton k $ NodeInfo (From_Insert v) Nothing
+insertMapKey k v = PatchMapWithMove' $ PM.insertMapKey k v
 
 -- |Make a @'PatchMapWithMove' k v@ which has the effect of moving the value from the first key @k@ to the second key @k@, equivalent to:
 --
@@ -101,13 +120,7 @@ insertMapKey k v = PatchMapWithMove . Map.singleton k $ NodeInfo (From_Insert v)
 --     'Map.delete' src (maybe map ('Map.insert' dst) (Map.lookup src map))
 -- @
 moveMapKey :: Ord k => k -> k -> PatchMapWithMove k v
-moveMapKey src dst
-  | src == dst = mempty
-  | otherwise =
-      PatchMapWithMove $ Map.fromList
-        [ (dst, NodeInfo (From_Move src) Nothing)
-        , (src, NodeInfo From_Delete (Just dst))
-        ]
+moveMapKey src dst = PatchMapWithMove' $ PM.moveMapKey src dst
 
 -- |Make a @'PatchMapWithMove' k v@ which has the effect of swapping two keys in the mapping, equivalent to:
 --
@@ -119,61 +132,36 @@ moveMapKey src dst
 --      . Map.delete a . Map.delete b $ map
 -- @
 swapMapKey :: Ord k => k -> k -> PatchMapWithMove k v
-swapMapKey src dst
-  | src == dst = mempty
-  | otherwise =
-    PatchMapWithMove $ Map.fromList
-      [ (dst, NodeInfo (From_Move src) (Just src))
-      , (src, NodeInfo (From_Move dst) (Just dst))
-      ]
+swapMapKey src dst = PatchMapWithMove' $ PM.swapMapKey src dst
 
 -- |Make a @'PatchMapWithMove' k v@ which has the effect of deleting a key in the mapping, equivalent to 'Map.delete'.
 deleteMapKey :: k -> PatchMapWithMove k v
-deleteMapKey k = PatchMapWithMove . Map.singleton k $ NodeInfo From_Delete Nothing
+deleteMapKey = PatchMapWithMove' . PM.deleteMapKey
 
 -- | Wrap a @'Map' k (NodeInfo k v)@ representing patch changes into a @'PatchMapWithMove' k v@, without checking any invariants.
 --
 -- __Warning:__ when using this function, you must ensure that the invariants of 'PatchMapWithMove' are preserved; they will not be checked.
 unsafePatchMapWithMove :: Map k (NodeInfo k v) -> PatchMapWithMove k v
-unsafePatchMapWithMove = PatchMapWithMove
+unsafePatchMapWithMove = PatchMapWithMove' . PM.unsafePatchMapWithPatchingMove
 
 -- | Apply the insertions, deletions, and moves to a given 'Map'
 instance Ord k => Patch (PatchMapWithMove k v) where
   type PatchTarget (PatchMapWithMove k v) = Map k v
-  apply (PatchMapWithMove p) old = Just $! insertions `Map.union` (old `Map.difference` deletions) --TODO: return Nothing sometimes --Note: the strict application here is critical to ensuring that incremental merges don't hold onto all their prerequisite events forever; can we make this more robust?
-    where insertions = flip Map.mapMaybeWithKey p $ \_ ni -> case _nodeInfo_from ni of
-            From_Insert v -> Just v
-            From_Move k -> Map.lookup k old
-            From_Delete -> Nothing
-          deletions = flip Map.mapMaybeWithKey p $ \_ ni -> case _nodeInfo_from ni of
-            From_Delete -> Just ()
-            _ -> Nothing
+  apply (PatchMapWithMove' p) old = apply p old
 
 -- | Returns all the new elements that will be added to the 'Map'.
 patchMapWithMoveNewElements :: PatchMapWithMove k v -> [v]
-patchMapWithMoveNewElements = Map.elems . patchMapWithMoveNewElementsMap
+patchMapWithMoveNewElements = PM.patchMapWithPatchingMoveNewElements . unPatchMapWithMove'
 
 -- | Return a @'Map' k v@ with all the inserts/updates from the given @'PatchMapWithMove' k v@.
 patchMapWithMoveNewElementsMap :: PatchMapWithMove k v -> Map k v
-patchMapWithMoveNewElementsMap (PatchMapWithMove p) = Map.mapMaybe f p
-  where f ni = case _nodeInfo_from ni of
-          From_Insert v -> Just v
-          From_Move _ -> Nothing
-          From_Delete -> Nothing
+patchMapWithMoveNewElementsMap = PM.patchMapWithPatchingMoveNewElementsMap . unPatchMapWithMove'
 
 -- | Create a 'PatchMapWithMove' that, if applied to the given 'Map', will sort
 -- its values using the given ordering function.  The set keys of the 'Map' is
 -- not changed.
 patchThatSortsMapWith :: Ord k => (v -> v -> Ordering) -> Map k v -> PatchMapWithMove k v
-patchThatSortsMapWith cmp m = PatchMapWithMove $ Map.fromList $ catMaybes $ zipWith g unsorted sorted
-  where unsorted = Map.toList m
-        sorted = sortBy (cmp `on` snd) unsorted
-        f (to, _) (from, _) = if to == from then Nothing else
-          Just (from, to)
-        reverseMapping = Map.fromList $ catMaybes $ zipWith f unsorted sorted
-        g (to, _) (from, _) = if to == from then Nothing else
-          let Just movingTo = Map.lookup to reverseMapping
-          in Just (to, NodeInfo (From_Move from) $ Just movingTo)
+patchThatSortsMapWith cmp = PatchMapWithMove' . PM.patchThatSortsMapWith cmp
 
 -- | Create a 'PatchMapWithMove' that, if applied to the first 'Map' provided,
 -- will produce a 'Map' with the same values as the second 'Map' but with the
@@ -186,102 +174,23 @@ patchThatChangesAndSortsMapWith cmp oldByIndex newByIndexUnsorted = patchThatCha
 -- | Create a 'PatchMapWithMove' that, if applied to the first 'Map' provided,
 -- will produce the second 'Map'.
 patchThatChangesMap :: (Ord k, Ord v) => Map k v -> Map k v -> PatchMapWithMove k v
-patchThatChangesMap oldByIndex newByIndex = patch
-  where oldByValue = Map.fromListWith Set.union $ swap . first Set.singleton <$> Map.toList oldByIndex
-        (insertsAndMoves, unusedValuesByValue) = flip runState oldByValue $ do
-          let f k v = do
-                remainingValues <- get
-                let putRemainingKeys remainingKeys = put $ if Set.null remainingKeys
-                      then Map.delete v remainingValues
-                      else Map.insert v remainingKeys remainingValues
-                case Map.lookup v remainingValues of
-                  Nothing -> return $ NodeInfo (From_Insert v) $ Just undefined -- There's no existing value we can take
-                  Just fromKs ->
-                    if k `Set.member` fromKs
-                    then do
-                      putRemainingKeys $ Set.delete k fromKs
-                      return $ NodeInfo (From_Move k) $ Just undefined -- There's an existing value, and it's here, so no patch necessary
-                    else do
-                      (fromK, remainingKeys) <- return . fromJust $ Set.minView fromKs -- There's an existing value, but it's not here; move it here
-                      putRemainingKeys remainingKeys
-                      return $ NodeInfo (From_Move fromK) $ Just undefined
-          Map.traverseWithKey f newByIndex
-        unusedOldKeys = fold unusedValuesByValue
-        pointlessMove k = \case
-          From_Move k' | k == k' -> True
-          _ -> False
-        keyWasMoved k = if k `Map.member` oldByIndex && not (k `Set.member` unusedOldKeys)
-          then Just undefined
-          else Nothing
-        patch = unsafePatchMapWithMove $ Map.filterWithKey (\k -> not . pointlessMove k . _nodeInfo_from) $ Map.mergeWithKey (\k a _ -> Just $ nodeInfoSetTo (keyWasMoved k) a) (Map.mapWithKey $ \k -> nodeInfoSetTo $ keyWasMoved k) (Map.mapWithKey $ \k _ -> NodeInfo From_Delete $ keyWasMoved k) insertsAndMoves oldByIndex
+patchThatChangesMap oldByIndex newByIndex = PatchMapWithMove' $
+  PM.patchThatChangesMap oldByIndex newByIndex
 
 -- | Change the 'From' value of a 'NodeInfo'
 nodeInfoMapFrom :: (From k v -> From k v) -> NodeInfo k v -> NodeInfo k v
-nodeInfoMapFrom f ni = ni { _nodeInfo_from = f $ _nodeInfo_from ni }
+nodeInfoMapFrom = PM.nodeInfoMapFrom
 
 -- | Change the 'From' value of a 'NodeInfo', using a 'Functor' (or
 -- 'Applicative', 'Monad', etc.) action to get the new value
-nodeInfoMapMFrom :: Functor f => (From k v -> f (From k v)) -> NodeInfo k v -> f (NodeInfo k v)
-nodeInfoMapMFrom f ni = fmap (\result -> ni { _nodeInfo_from = result }) $ f $ _nodeInfo_from ni
+nodeInfoMapMFrom
+  :: Functor f
+  => (From k v -> f (From k v))
+  -> NodeInfo k v -> f (NodeInfo k v)
+nodeInfoMapMFrom = PM.nodeInfoMapMFrom
 
 -- | Set the 'To' field of a 'NodeInfo'
 nodeInfoSetTo :: To k -> NodeInfo k v -> NodeInfo k v
-nodeInfoSetTo to ni = ni { _nodeInfo_to = to }
+nodeInfoSetTo = PM.nodeInfoSetTo
 
--- |Helper data structure used for composing patches using the monoid instance.
-data Fixup k v
-   = Fixup_Delete
-   | Fixup_Update (These (From k v) (To k))
-
--- |Compose patches having the same effect as applying the patches in turn: @'applyAlways' (p <> q) == 'applyAlways' p . 'applyAlways' q@
-instance Ord k => Semigroup (PatchMapWithMove k v) where
-  PatchMapWithMove ma <> PatchMapWithMove mb = PatchMapWithMove m
-    where
-      connections = Map.toList $ Map.intersectionWithKey (\_ a b -> (_nodeInfo_to a, _nodeInfo_from b)) ma mb
-      h :: (k, (Maybe k, From k v)) -> [(k, Fixup k v)]
-      h (_, (mToAfter, editBefore)) = case (mToAfter, editBefore) of
-        (Just toAfter, From_Move fromBefore)
-          | fromBefore == toAfter
-            -> [(toAfter, Fixup_Delete)]
-          | otherwise
-            -> [ (toAfter, Fixup_Update (This editBefore))
-               , (fromBefore, Fixup_Update (That mToAfter))
-               ]
-        (Nothing, From_Move fromBefore) -> [(fromBefore, Fixup_Update (That mToAfter))] -- The item is destroyed in the second patch, so indicate that it is destroyed in the source map
-        (Just toAfter, _) -> [(toAfter, Fixup_Update (This editBefore))]
-        (Nothing, _) -> []
-      mergeFixups _ Fixup_Delete Fixup_Delete = Fixup_Delete
-      mergeFixups _ (Fixup_Update a) (Fixup_Update b)
-        | This x <- a, That y <- b
-        = Fixup_Update $ These x y
-        | That y <- a, This x <- b
-        = Fixup_Update $ These x y
-      mergeFixups _ _ _ = error "PatchMapWithMove: incompatible fixups"
-      fixups = Map.fromListWithKey mergeFixups $ concatMap h connections
-      combineNodeInfos _ nia nib = NodeInfo
-        { _nodeInfo_from = _nodeInfo_from nia
-        , _nodeInfo_to = _nodeInfo_to nib
-        }
-      applyFixup _ ni = \case
-        Fixup_Delete -> Nothing
-        Fixup_Update u -> Just $ NodeInfo
-          { _nodeInfo_from = fromMaybe (_nodeInfo_from ni) $ getHere u
-          , _nodeInfo_to = fromMaybe (_nodeInfo_to ni) $ getThere u
-          }
-      m = Map.differenceWithKey applyFixup (Map.unionWithKey combineNodeInfos ma mb) fixups
-      getHere :: These a b -> Maybe a
-      getHere = \case
-        This a -> Just a
-        These a _ -> Just a
-        That _ -> Nothing
-      getThere :: These a b -> Maybe b
-      getThere = \case
-        This _ -> Nothing
-        These _ b -> Just b
-        That b -> Just b
-
---TODO: Figure out how to implement this in terms of PatchDMapWithMove rather than duplicating it here
--- |Compose patches having the same effect as applying the patches in turn: @'applyAlways' (p <> q) == 'applyAlways' p . 'applyAlways' q@
-instance Ord k => Monoid (PatchMapWithMove k v) where
-  mempty = PatchMapWithMove mempty
-  mappend = (<>)
+makeWrapped ''PatchMapWithMove

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -19,9 +19,7 @@
 module Data.Patch.MapWithMove
   ( PatchMapWithMove
     ( PatchMapWithMove
-    , -- | Extract the representation of the 'PatchMapWithMove' as a map of
-      -- 'NodeInfo'.
-      unPatchMapWithMove
+    , unPatchMapWithMove
     , ..
     )
   , patchMapWithMove
@@ -99,6 +97,8 @@ pattern Coerce x <- (coerce -> x)
 
 {-# COMPLETE PatchMapWithMove #-}
 pattern PatchMapWithMove :: Map k (NodeInfo k v) -> PatchMapWithMove k v
+-- | Extract the representation of the 'PatchMapWithMove' as a map of
+-- 'NodeInfo'.
 unPatchMapWithMove :: PatchMapWithMove k v -> Map k (NodeInfo k v)
 pattern PatchMapWithMove { unPatchMapWithMove } = PatchMapWithMove' (PatchMapWithPatchingMove (Coerce unPatchMapWithMove))
 

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -309,3 +309,4 @@ bitraverseFrom fk fv = fmap coerce
 
 makeWrapped ''PatchMapWithMove
 makeWrapped ''NodeInfo
+makeWrapped ''From

--- a/src/Data/Patch/MapWithPatchingMove.hs
+++ b/src/Data/Patch/MapWithPatchingMove.hs
@@ -136,8 +136,8 @@ moveMapKey src dst
 -- @
 --     let aMay = Map.lookup a map
 --         bMay = Map.lookup b map
---     in maybe id (Map.insert a) (bMay `mplus` aMay)
---      . maybe id (Map.insert b) (aMay `mplus` bMay)
+--     in maybe id (Map.insert a) (bMay <> aMay)
+--      . maybe id (Map.insert b) (aMay <> bMay)
 --      . Map.delete a . Map.delete b $ map
 -- @
 swapMapKey
@@ -281,6 +281,8 @@ deriving instance (Read k, Read p, Read (PatchTarget p)) => Read (NodeInfo k p)
 deriving instance (Eq k, Eq p, Eq (PatchTarget p)) => Eq (NodeInfo k p)
 deriving instance (Ord k, Ord p, Ord (PatchTarget p)) => Ord (NodeInfo k p)
 
+-- | Traverse the 'NodeInfo' over the key, patch, and patch target. Because of
+-- the type families here, this doesn't it any bi- or tri-traversal class.
 bitraverseNodeInfo
   :: Applicative f
   => (k0 -> f k1)
@@ -322,6 +324,8 @@ deriving instance (Read k, Read p, Read (PatchTarget p)) => Read (From k p)
 deriving instance (Eq k, Eq p, Eq (PatchTarget p)) => Eq (From k p)
 deriving instance (Ord k, Ord p, Ord (PatchTarget p)) => Ord (From k p)
 
+-- | Traverse the 'From' over the key, patch, and patch target. Because of
+-- the type families here, this doesn't it any bi- or tri-traversal class.
 bitraverseFrom
   :: Applicative f
   => (k0 -> f k1)


### PR DESCRIPTION
Per the change log, care is taken so this should not be a breaking change.

I had to to write explicit export lists to get around some obscure GHC bugs with reexport data types twice with different patterns nested for `(..)` imports, but I think it's nicer anyways as it makes comparability easier to check going forward.