### PR TITLE
Get rid of `fromJust` in other `PatchMapWith*Move` variant

### DIFF
--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -202,7 +202,9 @@ patchThatChangesMap oldByIndex newByIndex = patch
                       putRemainingKeys $ Set.delete k fromKs
                       return $ NodeInfo (From_Move k) $ Just undefined -- There's an existing value, and it's here, so no patch necessary
                     else do
-                      (fromK, remainingKeys) <- return . fromMaybe (error "patchThatChangesMap: impossible: fromKs was empty") $ Set.minView fromKs -- There's an existing value, but it's not here; move it here
+                      (fromK, remainingKeys) <- return $
+                        fromMaybe (error "PatchMapWithMove.patchThatChangesMap: impossible: fromKs was empty") $
+                        Set.minView fromKs -- There's an existing value, but it's not here; move it here
                       putRemainingKeys remainingKeys
                       return $ NodeInfo (From_Move fromK) $ Just undefined
           Map.traverseWithKey f newByIndex

--- a/src/Data/Patch/MapWithPatchingMove.hs
+++ b/src/Data/Patch/MapWithPatchingMove.hs
@@ -268,7 +268,9 @@ patchThatChangesMap oldByIndex newByIndex = patch
                       putRemainingKeys $ Set.delete k fromKs
                       return $ NodeInfo (From_Move k mempty) $ Just undefined -- There's an existing value, and it's here, so no patch necessary
                     else do
-                      (fromK, remainingKeys) <- return . fromJust $ Set.minView fromKs -- There's an existing value, but it's not here; move it here
+                      (fromK, remainingKeys) <- return $
+                        fromMaybe (error "PatchMapWithPatchingMove.patchThatChangesMap: impossible: fromKs was empty") $
+                        Set.minView fromKs -- There's an existing value, but it's not here; move it here
                       putRemainingKeys remainingKeys
                       return $ NodeInfo (From_Move fromK mempty) $ Just undefined
           Map.traverseWithKey f newByIndex


### PR DESCRIPTION
This is why I want to deduplicate them! Also, disambig error messages and shorten lines.