### PR TITLE
Bump a number of upper version bounds

### DIFF
--- a/patch.cabal
+++ b/patch.cabal
@@ -35,12 +35,12 @@ library
   build-depends: base >= 4.9 && < 4.14
                , constraints-extras >= 0.3 && < 0.4
                , containers >= 0.6 && < 0.7
-               , dependent-map >= 0.3 && < 0.4
-               , dependent-sum >= 0.6 && < 0.7
+               , dependent-map >= 0.3 && < 0.5
+               , dependent-sum >= 0.6 && < 0.8
                , lens >= 4.7 && < 5
                , semigroupoids >= 4.0 && < 6
                , transformers >= 0.5.6.0 && < 0.6
-               , witherable >= 0.3 && < 0.3.2
+               , witherable >= 0.3 && < 0.4
 
   exposed-modules: Data.Functor.Misc
                  , Data.Monoid.DecidablyEmpty
@@ -56,7 +56,7 @@ library
   ghc-options: -Wall -fwarn-redundant-constraints -fwarn-tabs
 
   if flag(split-these)
-    build-depends: these >= 1 && <1.1
+    build-depends: these >= 1 && <1.2
                  , semialign >=1 && <1.2
                  , monoidal-containers >= 0.6 && < 0.7
   else

--- a/src/Data/Functor/Misc.hs
+++ b/src/Data/Functor/Misc.hs
@@ -48,7 +48,7 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Some (Some(Some))
+import Data.Some (Some, mkSome)
 import Data.These
 import Data.Type.Equality ((:~:)(Refl))
 import Data.Typeable hiding (Refl)
@@ -117,7 +117,7 @@ intMapWithFunctorToDMap = DMap.fromDistinctAscList . map (\(k, v) -> Const2 k :=
 -- | Convert a 'DMap' to a regular 'Map' by forgetting the types associated with
 -- the keys, using a function to remove the wrapping 'Functor'
 weakenDMapWith :: (forall a. v a -> v') -> DMap k v -> Map (Some k) v'
-weakenDMapWith f = Map.fromDistinctAscList . map (\(k :=> v) -> (Some k, f v)) . DMap.toAscList
+weakenDMapWith f = Map.fromDistinctAscList . map (\(k :=> v) -> (mkSome k, f v)) . DMap.toAscList
 
 --------------------------------------------------------------------------------
 -- WrapArg

--- a/src/Data/Patch/DMap.hs
+++ b/src/Data/Patch/DMap.hs
@@ -14,7 +14,9 @@ import Data.Patch.Class
 import Data.Patch.IntMap
 import Data.Patch.Map
 
-import Data.Dependent.Map (DMap, DSum (..), GCompare (..))
+import Data.Dependent.Map (DMap)
+import Data.Dependent.Sum (DSum (..))
+import Data.GADT.Compare (GCompare (..))
 import qualified Data.Dependent.Map as DMap
 import Data.Functor.Constant
 import Data.Functor.Misc

--- a/src/Data/Patch/DMapWithMove.hs
+++ b/src/Data/Patch/DMapWithMove.hs
@@ -20,12 +20,13 @@ import Data.Patch.MapWithMove (PatchMapWithMove (..))
 import qualified Data.Patch.MapWithMove as MapWithMove
 
 import Data.Constraint.Extras
-import Data.Dependent.Map (DMap, DSum (..), GCompare (..))
+import Data.Dependent.Map (DMap)
+import Data.Dependent.Sum (DSum (..))
 import qualified Data.Dependent.Map as DMap
 import Data.Functor.Constant
 import Data.Functor.Misc
 import Data.Functor.Product
-import Data.GADT.Compare (GEq (..))
+import Data.GADT.Compare (GEq (..), GCompare (..))
 import Data.GADT.Show (GShow, gshow)
 import qualified Data.Map as Map
 import Data.Maybe
@@ -33,7 +34,7 @@ import Data.Monoid.DecidablyEmpty
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup (..))
 #endif
-import Data.Some (Some(Some))
+import Data.Some (Some, mkSome)
 import Data.These
 
 -- | Like 'PatchMapWithMove', but for 'DMap'. Each key carries a 'NodeInfo' which describes how it will be changed by the patch and connects move sources and
@@ -317,8 +318,8 @@ weakenPatchDMapWithMoveWith f (PatchDMapWithMove p) = PatchMapWithMove $ weakenD
           { MapWithMove._nodeInfo_from = case _nodeInfo_from ni of
               From_Insert v -> MapWithMove.From_Insert $ f v
               From_Delete -> MapWithMove.From_Delete
-              From_Move k -> MapWithMove.From_Move $ Some k
-          , MapWithMove._nodeInfo_to = Some <$> getComposeMaybe (_nodeInfo_to ni)
+              From_Move k -> MapWithMove.From_Move $ mkSome k
+          , MapWithMove._nodeInfo_to = mkSome <$> getComposeMaybe (_nodeInfo_to ni)
           }
 
 -- |"Weaken" a @'PatchDMapWithMove' (Const2 k a) v@ to a @'PatchMapWithMove' k v'@. Weaken is in scare quotes because the 'Const2' has already disabled any


### PR DESCRIPTION
Dependent.Map stopped some reexport, so I now export them from
their original modules.

I have to admit: I don't understand why witherable was pinned to the version 3.2 (which introduces instances for MonoidalMap). I have run the tests and everything seems to work with witherable 3.5.
