### PR TITLE
Correct field order of `PatchMapWithMove.NodeInfo`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Revision history for patch
 
+## 0.0.5.2 - 2022-01-09
+
+* Correct field order of `PatchMapWithMove.NodeInfo`.
+
+  When we this was reimplemented as a pattern synonym wrapper in 0.0.5.0, we
+  accidentally flipped the argument order. Reversing it now to match 0.0.4.0
+  and restore compatibility. The previous releases in the 0.0.5.\* series will
+  correspondingly be deprecated.
+
 ## 0.0.5.1 - 2021-12-28
 
 * New dep of `base-orphans` for old GHC to get instances honestly instead of

--- a/patch.cabal
+++ b/patch.cabal
@@ -1,5 +1,5 @@
 Name: patch
-Version: 0.0.5.1
+Version: 0.0.5.2
 Synopsis: Data structures for describing changes to other data structures.
 Description:
   Data structures for describing changes to other data structures.

--- a/src/Data/Patch/MapWithMove.hs
+++ b/src/Data/Patch/MapWithMove.hs
@@ -42,8 +42,8 @@ module Data.Patch.MapWithMove
   -- * Node Info
   , NodeInfo
     ( NodeInfo
-    , _nodeInfo_to
     , _nodeInfo_from
+    , _nodeInfo_to
     , ..
     )
   , bitraverseNodeInfo
@@ -228,13 +228,13 @@ deriving instance (Eq k, Eq p) => Eq (NodeInfo k p)
 deriving instance (Ord k, Ord p) => Ord (NodeInfo k p)
 
 {-# COMPLETE NodeInfo #-}
-pattern NodeInfo :: To k -> From k v -> NodeInfo k v
-_nodeInfo_to :: NodeInfo k v -> To k
+pattern NodeInfo :: From k v -> To k -> NodeInfo k v
 _nodeInfo_from :: NodeInfo k v -> From k v
-pattern NodeInfo { _nodeInfo_to, _nodeInfo_from } = NodeInfo'
+_nodeInfo_to :: NodeInfo k v -> To k
+pattern NodeInfo { _nodeInfo_from, _nodeInfo_to } = NodeInfo'
   PM.NodeInfo
-    { PM._nodeInfo_to = _nodeInfo_to
-    , PM._nodeInfo_from = Coerce _nodeInfo_from
+    { PM._nodeInfo_from = Coerce _nodeInfo_from
+    , PM._nodeInfo_to = _nodeInfo_to
     }
 
 _NodeInfo


### PR DESCRIPTION
See change log for details.

Fixes https://github.com/reflex-frp/reflex-dom/issues/431

CC @maralorn @ali-abrar 