### PR TITLE
Factor out Additive

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for patch
 
+## Unreleased
+
+ * Use `commutative-semigroups` for `Commutative`, making `Additive` a
+   deprecated alias.
+
 ## 0.0.5.2 - 2022-01-09
 
 * Correct field order of `PatchMapWithMove.NodeInfo`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,12 +1,14 @@
 # Revision history for patch
 
+## Unreleased
+
+* Use `commutative-semigroups` for `Commutative`, making `Additive` a
+  deprecated alias.
+
 ## 0.0.6.0 - 2022-06-10
 
 * Add `PatchOrReplacement`, patch which either is some other patch type or a
   new replacement value.
-
- * Use `commutative-semigroups` for `Commutative`, making `Additive` a
-   deprecated alias.
 
 * Support GHC 9.2
 

--- a/patch.cabal
+++ b/patch.cabal
@@ -35,7 +35,7 @@ library
   default-language: Haskell2010
   build-depends: base >= 4.9 && < 4.17
                , constraints-extras >= 0.3 && < 0.4
-               , commutative-semigroups >= 0.0 && < 0.1
+               , commutative-semigroups >= 0.0 && < 0.2
                , containers >= 0.6 && < 0.7
                , dependent-map >= 0.3 && < 0.5
                , dependent-sum >= 0.6 && < 0.8

--- a/patch.cabal
+++ b/patch.cabal
@@ -35,6 +35,7 @@ library
   default-language: Haskell2010
   build-depends: base >= 4.9 && < 4.15
                , constraints-extras >= 0.3 && < 0.4
+               , commutative-semigroups >= 0.0 && < 0.1
                , containers >= 0.6 && < 0.7
                , dependent-map >= 0.3 && < 0.5
                , dependent-sum >= 0.6 && < 0.8

--- a/src/Data/Patch.hs
+++ b/src/Data/Patch.hs
@@ -13,6 +13,7 @@ module Data.Patch
   , module X
   ) where
 
+import Data.Semigroup.Commutative
 import Control.Applicative
 import Data.Functor.Const (Const (..))
 import Data.Functor.Identity
@@ -46,10 +47,10 @@ class (Semigroup q, Monoid q) => Group q where
   (~~) :: q -> q -> q
   r ~~ s = r <> negateG s
 
--- | The elements of an 'Additive' 'Semigroup' can be considered as patches of their own type.
+-- | The elements of an 'Commutative' 'Semigroup' can be considered as patches of their own type.
 newtype AdditivePatch p = AdditivePatch { unAdditivePatch :: p }
 
-instance Additive p => Patch (AdditivePatch p) where
+instance Commutative p => Patch (AdditivePatch p) where
   type PatchTarget (AdditivePatch p) = p
   apply (AdditivePatch p) q = Just $ p <> q
 

--- a/src/Data/Patch.hs
+++ b/src/Data/Patch.hs
@@ -24,7 +24,7 @@ import Data.Semigroup (Semigroup (..))
 #endif
 import GHC.Generics
 
-import Data.Semigroup.Additive as X
+import qualified Data.Semigroup.Additive as X
 import Data.Patch.Class as X
 import Data.Patch.DMap as X hiding (getDeletions)
 import Data.Patch.DMapWithMove as X

--- a/src/Data/Semigroup/Additive.hs
+++ b/src/Data/Semigroup/Additive.hs
@@ -1,52 +1,14 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
 
 {-|
 Description : A class for commutative semigroups
 -}
 module Data.Semigroup.Additive
+  {-# DEPRECATED "Use 'Data.Semigroup.Commutative'" #-}
   ( Additive
   ) where
 
-import Data.Functor.Const (Const (..))
-import Data.Functor.Identity
-import Data.Proxy
-#if !MIN_VERSION_base(4,12,0)
--- for :*: and :.: semigroup instances
-import Data.Orphans ()
-#endif
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup (Semigroup (..))
-#endif
-import GHC.Generics
+import Data.Semigroup.Commutative
 
--- | An 'Additive' 'Semigroup' is one where (<>) is commutative
-class Semigroup q => Additive q where
-
--- | Trivial additive semigroup.
-instance Additive ()
-
--- | Product additive semigroup.
--- A Pair of additive semigroups gives rise to a additive semigroup
-instance (Additive a, Additive b) => Additive (a, b)
-
--- See https://gitlab.haskell.org/ghc/ghc/issues/11135#note_111802 for the reason Compose is not also provided.
--- Base does not define Monoid (Compose f g a) so this is the best we can
--- really do for functor composition.
-instance Additive (f (g a)) => Additive ((f :.: g) a)
-
--- | Product of additive semigroups, Functor style.
-instance (Additive (f a), Additive (g a)) => Additive ((f :*: g) a)
-
--- | Trivial additive semigroup, Functor style
-instance Additive (Proxy x)
-
--- | Const lifts additive semigroups into a functor.
-instance Additive a => Additive (Const a x)
-
--- | Identity lifts additive semigroups pointwise (at only one point)
-instance Additive a => Additive (Identity a)
-
--- | Functions lift additive semigroups pointwise.
-instance Additive b => Additive (a -> b)
+{-# DEPRECATED Additive "Use 'Data.Semigroup.Commutative.Commutative'" #-}
+type Additive = Commutative


### PR DESCRIPTION
Use `commutative-semigroups` for `Commutative`, making `Additive` a
deprecated alias.