### PR TITLE
Reorder TH statements for ghc 9.0 compatibility

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1']
         os: ['ubuntu-latest', 'macos-latest']
         exclude:
           # There are some linker warnings in 802 on darwin that

--- a/src/Data/Patch/Map.hs
+++ b/src/Data/Patch/Map.hs
@@ -63,6 +63,8 @@ instance Ord k => Patch (PatchMap k v) where
             Nothing -> Just ()
             Just _ -> Nothing
 
+makeWrapped ''PatchMap
+
 instance FunctorWithIndex k (PatchMap k)
 instance FoldableWithIndex k (PatchMap k)
 instance TraversableWithIndex k (PatchMap k) where
@@ -81,5 +83,3 @@ patchMapNewElements (PatchMap p) = catMaybes $ Map.elems p
 -- | Returns all the new elements that will be added to the 'Map'
 patchMapNewElementsMap :: PatchMap k v -> Map k v
 patchMapNewElementsMap (PatchMap p) = Map.mapMaybe id p
-
-makeWrapped ''PatchMap


### PR DESCRIPTION
I am uncertain as to why this did build with previous ghc versions. But ghc 9.0 needs this in this order …