### PR TITLE
Modernize github actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,30 +14,44 @@ jobs:
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: haskell/actions/setup@v2
+    - name: Set up GHC ${{ matrix.ghc-version }}
+      uses: haskell-actions/setup@v2
+      id: setup
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.10.3.0'
 
-    - name: Cache
-      uses: actions/cache@v3
+    - name: Configure the build
+      run: |
+        cabal configure --enable-tests --enable-benchmarks --disable-documentation
+        cabal build all --dry-run
+      # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v4
+      id: cache
       env:
-        cache-name: cache-cabal
+        key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-build-
-          ${{ runner.os }}-${{ matrix.ghc }}-
-          ${{ runner.os }}
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+        restore-keys: ${{ env.key }}-
 
     - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+      # If we had an exact cache hit, the dependencies will be up to date.
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: cabal build --only-dependencies --enable-tests --enable-benchmarks
+
+    # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+    - name: Save cached dependencies
+      uses: actions/cache/save@v4
+      # If we had an exact cache hit, trying to save the cache would error because of key clash.
+      if: steps.cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}
 
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
@@ -46,7 +60,10 @@ jobs:
       # We don't run hlint tests, because different versions of hlint have different suggestions, and we don't want to worry about satisfying them all.
       run: cabal test --enable-tests -f-hlint all
 
-    - if: matrix.ghc != '8.4.4'
+    # - name: Check cabal file
+    #   run: cabal check
+
+    - name: Build documentation
       # docs aren't built on ghc 8.4.4 because some dependency docs don't build on older GHCs
-      name: Build Docs
-      run: cabal haddock
+      if: matrix.ghc != '8.4.4'
+      run: cabal haddock all


### PR DESCRIPTION
- Use newer Cabal that knows about GHC 9.10

- Use non-deprecated haskell GitHub actions