### PR TITLE
Fix re-export fix

### DIFF
--- a/src/Data/Patch.hs
+++ b/src/Data/Patch.hs
@@ -30,7 +30,7 @@ import Data.Semigroup (Semigroup (..))
 
 -- N.B. Intentionally reexporting `Additive`, the deprecated alias, as
 -- this is a reexport for backwards compatibility.
-import qualified Data.Semigroup.Additive as X
+import Data.Semigroup.Additive as X
 import Data.Patch.Class as X
 import Data.Patch.DMap as X hiding (getDeletions)
 import Data.Patch.DMapWithMove as X


### PR DESCRIPTION
We currently have
```
src/Data/Patch.hs:33:1: warning: [-Wunused-imports]
    The qualified import of ‘Data.Semigroup.Additive’ is redundant
   |
33 | import qualified Data.Semigroup.Additive as X
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
``` 

By doing 
```diff
+  , module Y
   ) where
 
 import Data.Semigroup.Commutative
@@ -30,7 +31,7 @@ import Data.Semigroup (Semigroup (..))
 
 -- N.B. Intentionally reexporting `Additive`, the deprecated alias, as
 -- this is a reexport for backwards compatibility.
-import qualified Data.Semigroup.Additive as X
+import qualified Data.Semigroup.Additive as Y
```
we get
```
src/Data/Patch.hs:14:5-12: warning: [GHC-64649] [-Wdodgy-exports]
    The export item ‘module Y’ exports nothing
   |
14 |   , module Y
   |     ^^^^^^^^
src/Data/Patch.hs:34:1-45: warning: [-Wunused-imports]
    The qualified import of ‘Data.Semigroup.Additive’ is redundant
   |
34 | import qualified Data.Semigroup.Additive as Y
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

whereas removing `qualified` makes the warning go away in both X and Y cases.

I don't get it either but ghc 8.4 and 9.10 agree on this